### PR TITLE
Support paths with global pattern symbols

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -72,7 +72,7 @@ class LCUConnector extends EventEmitter {
         }
 
         const lockfilePath = path.join(this._dirPath, 'lockfile');
-        this._lockfileWatcher = chokidar.watch(lockfilePath);
+        this._lockfileWatcher = chokidar.watch(lockfilePath, { disableGlobbing: true });
 
         this._lockfileWatcher.on('add', this._onFileCreated.bind(this));
         this._lockfileWatcher.on('unlink', this._onFileRemoved.bind(this));


### PR DESCRIPTION
On chokidar watcher globbing it's used to retrieve files with global pattern (./*.js for example), this causes don't send watcher events on folders with global pattern simbols like "Program Files (x86)" or "Folder [1]"

lcu-connector don't need globbing because it's always watching for lockfile, disabling it can support all folders safely