### PR TITLE
Fire connect event on lockfile change

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -77,6 +77,7 @@ class LCUConnector extends EventEmitter {
         this._lockfileWatcher = chokidar.watch(lockfilePath, { disableGlobbing: true });
 
         this._lockfileWatcher.on('add', this._onFileCreated.bind(this));
+        this._lockfileWatcher.on('change', this._onFileCreated.bind(this));
         this._lockfileWatcher.on('unlink', this._onFileRemoved.bind(this));
     }
 


### PR DESCRIPTION
If the league client is terminated uncleanly (if it crashes or is killed with the Task Manager, etc), it fails to remove the lockfile. The next time the client is started, it will overwrite the lockfile instead of deleting and re-creating it, and the connect event is not fired.