### PR TITLE
Make path for constructor optional in Typescript.

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -1,5 +1,5 @@
 declare class LCUConnector {
-        constructor(path: string);
+        constructor(path?: string);
 
         static getLCUPathFromProcess(): Promise<string | void>;
 


### PR DESCRIPTION
It currently throws a build error when you try to. This fixes it.